### PR TITLE
Suggestion to a download link in addition to download by right click

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
           Adjust Intensity here: <input type="range" value="2" id="intensity" name="intensity" min="2" max="12">
         </div>
         <div class="control">
-          Right click and save here: <img id="image" />
+          <a class="fancy-download" href="" download>Click here to save the intensified:</a> <img id="image" />
         </div>
       </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -91,6 +91,7 @@ function makeShakyBoi(char, intensity) {
 
   document.getElementById("image").src = dataUrl
   document.querySelector('.bg').style.backgroundImage = `url(${dataUrl})`
+  document.querySelector('.fancy-download').href = dataUrl;
 }
 
 

--- a/style.css
+++ b/style.css
@@ -56,6 +56,12 @@ h1 {
   min-height: 40px;
 }
 
+.fancy-download {
+  text-align: center;
+  font-weight: bold;
+  color: currentColor;
+}
+
 input[type=text] {
   text-align: center;
   font-size: 30px;


### PR DESCRIPTION
Some mobile browsers treat blob object URLs differently from normal URLs, and do not show an option to download a file over the context menu. 